### PR TITLE
Set up a GitHub Actions workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,99 @@
+name: Main
+
+on:
+  push:
+    branches: [ main, wip ]
+  pull_request:
+    branches: [ main ]
+  schedule:
+    # Every twelve (12) hours.
+    # @see https://crontab.guru/every-12-hours
+    - cron: 0 */12 * * *
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: "${{ matrix.os }}-latest"
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu ]
+        php: [ 8.1, 8.2, 8.3 ]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4 # https://github.com/marketplace/actions/checkout
+
+      - name: Set up PHP CLI
+        uses: shivammathur/setup-php@v2 # https://github.com/marketplace/actions/setup-php-action
+        with:
+          php-version: "${{ matrix.php }}"
+
+      - name: Create project
+        run: |
+          set -o xtrace
+
+          # Prepare the target directory.
+          sudo mkdir -p /var/www
+          sudo rm -rf /var/www/*
+          sudo chmod 777 /var/www
+
+          # Create the project.
+          git checkout -b main
+          composer create-project \
+            --stability=dev \
+            --repository='{"type":"vcs","url":"'"$(pwd)"'"}' \
+            --ansi \
+            drupal/starshot-project \
+            /var/www
+          cd /var/www
+
+          # Enable verbose error logging (debug mode).
+          ./vendor/bin/drush config:set --yes system.logging error_level verbose
+          ./vendor/bin/drush config:get system.logging error_level
+
+          # @todo The above Drush command doesn't ultimately take effect
+          #   for some reason. Manually change the settings until it can
+          #   be debugged.
+          echo "if (file_exists(__DIR__ . '/settings.local.php')) {
+            include __DIR__ . '/settings.local.php';
+          }" | sudo tee -a web/sites/default/settings.php
+          sudo cp web/sites/example.settings.local.php \
+            web/sites/default/settings.local.php
+
+          # Make everything writable.
+          sudo chmod -R 777 /var/www/web
+
+      - name: Set up Apache on Linux
+        if: runner.os == 'Linux'
+        run: |
+          set -o xtrace
+
+          # Install Apache w/ PHP.
+          sudo add-apt-repository ppa:ondrej/php
+          sudo add-apt-repository ppa:ondrej/apache2
+          sudo apt update
+          sudo apt install \
+            apache2 \
+            php${{ matrix.php }} \
+            libapache2-mod-php${{ matrix.php }}
+          sudo a2enmod php${{ matrix.php }}
+
+          # Change the default site web directory.
+          sudo sed -i 's/\/var\/www\/html/\/var\/www\/web/g' /etc/apache2/sites-enabled/000-default.conf
+
+          # Start the service.
+          sudo service apache2 start
+
+      - name: Debugging
+        if: runner.os == 'macOS'
+        run: |
+          php -v | head -1
+          php --ini
+
+      - name: Test
+        run: |
+          set -o xtrace
+
+          php /var/www/vendor/bin/drush core:status
+          curl http://localhost/ 2>/dev/null

--- a/composer.json
+++ b/composer.json
@@ -136,7 +136,7 @@
         "post-create-project-cmd": [
             "@drupal:install",
             "Composer\\Config::disableProcessTimeout",
-            "@php web/core/scripts/drupal quick-start"
+            "test -n \"$CI\" || php -d max_execution_time=0 web/core/scripts/drupal quick-start"
         ]
     },
     "scripts-descriptions": {


### PR DESCRIPTION
- Part One of https://github.com/phenaproxima/drupal-suite/issues/1

---

- [x] Build the project the way it would be used in real life (via `composer create-project`, not just `composer install`)
- [x] Test against PHP 8.1, 8.2, and 8.3
- [x] Also against Ubuntu (macOS and Windows deferred to a follow-up)
- [x] Run automatically...
	- [x] every 12 hours
	- [x] on pushes to `main` and `wip`
	- [x] on PRs to `main` and `develop`
	- [x] when triggered manually
- [x] The `web` directory should be served by Apache

### Notes

- Per discussion with you, macOS and Windows support have been deferred to an as-yet unprioritized follow-up issue.
- I configured it to run on pushes and pull requests, even though that wasn't explicitly in the requirements, because it seemed obvious and I assume you would want it.
- This doesn't install Nightwatch or any supplementary testing requirements, as they weren't in the success criteria. Obviously, they can be added in follow-ups as necessary.
- ~I assume that Apache is multi-threaded by default, but I haven't confirmed it. I don't know, for example, if it has to have [the MPM worker](https://httpd.apache.org/docs/2.4/mod/worker.html) specifically enabled. Unless you know the answer, I'll check on it (or it will become evident as soon as you try to do something in the build that requires it).~ This will be deferred to a follow-up, depending on whether it turns out to actually be an issue.
