### PR TITLE
Remove the line for the project name from ddev config.yaml

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -1,4 +1,3 @@
-name: starshot
 type: drupal
 ddev_version_constraint: '>=1.23.0'
 docroot: web


### PR DESCRIPTION
If you are trying to follow along 

```
git clone https://github.com/phenaproxima/starshot-prototype.git starshot
cd starshot && ddev install
```
that totally works fine for the first instance on your computer. but from this point on the name `starshot` is taken. if you try to git clone and spin up a second instance you will run into the following name conflict: 

```
$> ddev install
Starting starshot... 
Failed to start starshot: project starshot project root is already set to /Users/rkoller/Sites/starshot, refusing to change it to /Users/rkoller/Sites/lala; you can `ddev stop --unlist starshot` and start again if the listed project root is in error 
Failed to start starshot: project starshot project root is already set to /Users/rkoller/Sites/starshot, refusing to change it to /Users/rkoller/Sites/lala; you can `ddev stop --unlist starshot` and start again if the listed project root is in error
Failed to start starshot: project starshot project root is already set to /Users/rkoller/Sites/starshot, refusing to change it to /Users/rkoller/Sites/lala; you can `ddev stop --unlist starshot` and start again if the listed project root is in error
```

the easiest fix making this approach more flexible is simply avoid to set the project name in the config.yaml file. I've also quickly asked @rfay and he agreed and that life would be a lot easier if this line would be left out. 